### PR TITLE
Change of an ID

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,7 +743,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-object" id="Object">Object</a> </li>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-orderedcollection" id="OrderedCollection">OrderedCollection</a> </li>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-orderedcollectionpage" id="OrderedCollectionPage">OrderedCollectionPage</a> </li>
-      <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-organization" id="Organisations">Organization</a> </li>
+      <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-organization" id="Organization">Organization</a> </li>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-page" id="Page">Page</a> </li>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-person" id="Person">Person</a> </li>
       <li><a href="https://www.w3.org/TR/activitystreams-vocabulary#dfn-place" id="Place">Place</a> </li>


### PR DESCRIPTION
The `@id` for the term "Organization" should be the same; it was "Organisations".

(Pubrules complain about this when checking the Annotation Vocabulary Rec...)